### PR TITLE
Removed submodule wp-content/plugins/client-hosting-manager

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "tools"]
 	path = tools
 	url = git@github.com:INN/deploy-tools.git
-[submodule "wp-content/plugins/client-hosting-manager"]
-	path = wp-content/plugins/client-hosting-manager
-	url = git@github.com:INN/client-hosting-manager.git
 [submodule "wp-content/themes/largo"]
 	path = wp-content/themes/largo
 	url = git@github.com:INN/Largo.git


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Removes the client hosting manager submodule and plugin

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #22

## Testing/Questions

Features that this PR affects:

- Client Hosting Manager

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?

Steps to test this PR:

1. Poke around the site and make sure nothing is broken